### PR TITLE
Align with recent changes to Oracle docker-images

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Build the Docker image with the database:
 ```
 cd docker-images/OracleDatabase/SingleInstance/dockerfiles
 cp /vagrant_data/linuxx64_12201_database.zip 12.2.0.1
-./buildDockerImage.sh -v 12.2.0.1 -i -e
+./buildContainerImage.sh -v 12.2.0.1 -i -e
 ```
 
 Create a data directory and run the container:


### PR DESCRIPTION
The Oracle docker-images repository changed the name of the script from buildDockerImage.sh to buildContainerImage.sh.